### PR TITLE
CI test: Limit line length to 100 MB to not exhaust system memory on `/dev/zero`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Python syntax highlighting no longer suffers from abysmal performance in specific scenarios. See #1688 (@keith-hall)
 - First line not shown in diff context. See #1891 (@divagant-martian)
 - Do not ignore syntaxes that handle file names with a `*.conf` extension. See #1703 (@cbolgiano)
+- Limit line length to 100 MB to not exhaust system memory on `/dev/zero`. See #1972 (@Enselic)
 
 ## Performance
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -344,6 +344,18 @@ fn no_args_doesnt_break() {
     assert!(exit_status.success());
 }
 
+#[cfg(unix)]
+#[test]
+fn dev_zero() {
+    bat()
+        .arg("/dev/zero")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Lines longer than 100 MB are not supported",
+        ));
+}
+
 #[test]
 fn tabs_numbers() {
     bat()


### PR DESCRIPTION
Closes #636