### PR TITLE
Make releases easier, print `-h`, `--help` and `man` in CI

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -118,6 +118,18 @@ jobs:
         toolchain: stable
         default: true
         profile: minimal
+    - name: Print -h
+      uses: actions-rs/cargo@v1
+      with:
+        command: run
+        args: --locked -- -h
+    - name: Print --help
+      uses: actions-rs/cargo@v1
+      with:
+        command: run
+        args: --locked -- --help
+    - name: Show man page
+      run: man $(find . -name bat.1) | tee
     - name: Check documentation
       env:
         RUSTDOCFLAGS: -D warnings

--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -20,8 +20,8 @@
 
 ## Documentation
 
-- [ ] Review the `-h` and `--help` texts
-- [ ] Review the `man` page (`man $(fd -HIp target/release/build.*out/assets/manual/bat.1) | tee`)
+- [ ] Review `-h`, `--help`, and the `man` page. All of these are shown in
+      the output of the CI job called *Documentation*, so look there.
 
 ## Pre-release checks
 


### PR DESCRIPTION
Use CI to simplify release-checklist.md steps with regards to help and man.